### PR TITLE
Make parallelization smarter

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "license": "BSD",
   "main": "tools/web-tools-test-unit.js",
   "dependencies": {
-    "gulp-filter": "6.0.0",
     "gulp-util": "3.0.7",
     "jasmine": "3.4.0",
     "jasmine-core": "3.4.0",
@@ -24,7 +23,6 @@
     "lodash": "4.6.1",
     "merge2": "1.0.1",
     "puppeteer": "1.19.0",
-    "stream-combiner": "0.2.2",
     "through2": "2.0.1",
     "yargs": "13.3.0"
   }

--- a/tools/tasks/task.test-unit.js
+++ b/tools/tasks/task.test-unit.js
@@ -1,7 +1,6 @@
 var _ = require('lodash'),
     args = require('yargs').argv,
     combine = require('stream-combiner'),
-    filter = require('gulp-filter')
     merge = require('merge2'),
     through = require('through2'),
     unitTestPipeline = require('../pipelines/pipeline.test-unit.js');


### PR DESCRIPTION
This PR adds some logic to smartly choose between using 1 and 7 cores when parallelizing tests. To do this, I've added an additional pipe to the test file pipeline that labels test files so they can be easily counted later to determine how many cores to use.