### PR TITLE
Add new `maxParallel` option

### DIFF
--- a/tools/pipelines/pipeline.test-unit.js
+++ b/tools/pipelines/pipeline.test-unit.js
@@ -2,10 +2,7 @@ var path = require('path'),
     _ = require('lodash'),
     through = require('through2'),
     gutil = require('gulp-util'),
-    KarmaServer = require('karma').Server,
-    PARALLEL_THRESHOLD;
-
-PARALLEL_THRESHOLD = 5;
+    KarmaServer = require('karma').Server;
 
 process.env.CHROME_BIN = require('puppeteer').executablePath();
 
@@ -20,6 +17,8 @@ module.exports = function setupTestUnitPipeline(gulp) {
       reporters: ['progress'],
       browsers: ['ChromeHeadless'],
       captureTimeout: 20 * 1000,
+
+      maxParallel: 7,
 
       autoWatch: false,
       singleRun: true,
@@ -55,10 +54,10 @@ module.exports = function setupTestUnitPipeline(gulp) {
                   files: karmaFiles
                 });
 
-          if (testFileCount >= PARALLEL_THRESHOLD) {
-            _.set(karmaOptions, 'parallelOptions.executors', 7);
+          if (testFileCount < options.parallelization.maxParallel) {
+            _.set(karmaOptions, 'parallelOptions.executors', testFileCount);
           } else {
-            _.set(karmaOptions, 'parallelOptions.executors', 1);
+            _.set(karmaOptions, 'parallelOptions.executors', options.parallelization.maxParallel);
           }
 
           new KarmaServer(karmaOptions, function onFinish(exitCode) {


### PR DESCRIPTION
This PR adds a new option `maxParallel` to the `test-unit` task, which will allow us to tweak the number of parallel test files we run on a per-environment basis. Hopefully this should mitigate flooded cores in the future, as we've been finding for some projects on CircleCI.

I've also slightly re-factored the logic used when trying to run fewer test files than the maximum number of allowed parallel tests. Previously if we tried to run fewer than the hardcoded 7 parallel files, we'd just fall back to always running 1 file at a time. I've changed that so that if we try to run fewer than `maxParallel` files, it still runs each file in parallel.