### PR TITLE
Updates for gulp 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1550,9 +1550,9 @@
       }
     },
     "merge2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.0.1.tgz",
-      "integrity": "sha1-1O7u4awjCkq8KywIkTb9a0XPmvM="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
     "mime": {
       "version": "2.4.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "karma-jasmine-matchers": "4.0.2",
     "karma-parallel": "^0.3.1",
     "lodash": "4.17.21",
-    "merge2": "1.0.1",
+    "merge2": "^1.4.1",
     "puppeteer": "1.19.0",
     "through2": "2.0.1",
     "yargs": "13.3.0"


### PR DESCRIPTION
This PR updates the `web-tools-test-unit` task to be compatible with gulp 4 and our corresponding `web-tools` update. I updated the `test-unit` task to use `gulp.series()` and the `merge` method for merging our streams so they're in series and not parallel. 